### PR TITLE
refactor: Add Wrapper for IOCTL calls

### DIFF
--- a/serial/ioctl.go
+++ b/serial/ioctl.go
@@ -1,0 +1,11 @@
+package serial
+
+import "golang.org/x/sys/unix"
+
+func ioctl(command int, fd, ret uintptr) error {
+	_, _, err := unix.Syscall(unix.SYS_IOCTL, fd, uintptr(command), ret)
+	if err != 0 {
+		return unix.Errno(err)
+	}
+	return nil
+}

--- a/serial/open_linux.go
+++ b/serial/open_linux.go
@@ -138,18 +138,9 @@ func openInternal(options OpenOptions) (*Port, error) {
 	}
 
 	// Set our termios2 struct as the file descriptor's settings
-	r, _, errno := unix.Syscall(
-		unix.SYS_IOCTL,
-		uintptr(file.Fd()),
-		uintptr(unix.TCSETS2),
-		uintptr(unsafe.Pointer(t2)))
-
-	if errno != 0 {
-		return nil, os.NewSyscallError("SYS_IOCTL", errno)
-	}
-
-	if r != 0 {
-		return nil, errors.New("unknown error from SYS_IOCTL")
+	errno := ioctl(unix.TCSETS2, file.Fd(), uintptr(unsafe.Pointer(t2)))
+	if errno != nil {
+		return nil, errno
 	}
 
 	return NewPort(file), nil

--- a/serial/port_linux.go
+++ b/serial/port_linux.go
@@ -31,8 +31,8 @@ func (p *Port) Close() error {
 func (p *Port) InWaiting() (int, error) {
 	// Funky time
 	var waiting int
-	_, _, err := unix.Syscall(unix.SYS_IOCTL, p.f.Fd(), unix.TIOCINQ, uintptr(unsafe.Pointer(&waiting)))
-	if err != 0 {
+	err := ioctl(unix.TIOCINQ, p.f.Fd(), uintptr(unsafe.Pointer(&waiting)))
+	if err != nil {
 		return 0, err
 	}
 	return waiting, nil


### PR DESCRIPTION
Since we will be using these calls a lot with the port, it makes sense to simplify the syscalls to IOCTL.  This also lets us use the idiomatic ` if err != nil` on ioctl calls, rather than having to remember that we need to check for `if err != 0`. 

Tested with the current plantiga-connector.go 