### PR TITLE
feat: add SetDeadline method to port

### DIFF
--- a/serial/interfaces.go
+++ b/serial/interfaces.go
@@ -9,5 +9,5 @@ import (
 type port interface {
 	io.ReadWriteCloser
 	Inwaiting() (int, error)
-	SetTimeout(time.Time) error
+	SetDeadline(time.Time) error
 }

--- a/serial/port_linux.go
+++ b/serial/port_linux.go
@@ -38,9 +38,12 @@ func (p *Port) InWaiting() (int, error) {
 	return waiting, nil
 }
 
-func (p *Port) SetTimeout(t time.Time) error {
+func (p *Port) SetDeadline(t time.Time) error {
 	// Funky Town
-	// todo(ahollist): Implement
+	err := p.f.SetDeadline(t)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
Turns out os.File already has a SetDeadline method :) 

This sets an *absolute* time deadline for reads and writes, letting us choose exactly when to return from those calls. 