### PR TITLE
chore: Update Docs

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,7 +32,7 @@ Set up a `serial.OpenOptions` struct, then call `serial.Open`. For example:
 ````go
     import "fmt"
     import "log"
-    import "github.com/jacobsa/go-serial/serial"
+    import "github.com/Plantiga/simple-go-serial/serial"
 
     ...
 

--- a/serial/ioctl.go
+++ b/serial/ioctl.go
@@ -2,6 +2,7 @@ package serial
 
 import "golang.org/x/sys/unix"
 
+// ioctl provides a wrapper around the unix.Syscall, returning errors that general go code can deal with
 func ioctl(command int, fd, ret uintptr) error {
 	_, _, err := unix.Syscall(unix.SYS_IOCTL, fd, uintptr(command), ret)
 	if err != 0 {

--- a/serial/ioctl.go
+++ b/serial/ioctl.go
@@ -2,7 +2,7 @@ package serial
 
 import "golang.org/x/sys/unix"
 
-// ioctl provides a wrapper around the unix.Syscall, returning errors that general go code can deal with
+// ioctl provides a wrapper around the unix.Syscall, returning nil error on success instead of 0
 func ioctl(command int, fd, ret uintptr) error {
 	_, _, err := unix.Syscall(unix.SYS_IOCTL, fd, uintptr(command), ret)
 	if err != 0 {

--- a/serial/open_linux.go
+++ b/serial/open_linux.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	NCCS = 19
+	nccs = 19
 )
 
 //
@@ -25,7 +25,7 @@ type termios2 struct {
 	c_cflag  tcflag_t   // control mode flags
 	c_lflag  tcflag_t   // local mode flags
 	c_line   cc_t       // line discipline
-	c_cc     [NCCS]cc_t // control characters
+	c_cc     [nccs]cc_t // control characters
 	c_ispeed speed_t    // input speed
 	c_ospeed speed_t    // output speed
 }
@@ -50,7 +50,7 @@ func makeTermios2(options OpenOptions) (*termios2, error) {
 		return nil, errors.New("invalid value for InterCharacterTimeout")
 	}
 
-	ccOpts := [NCCS]cc_t{}
+	ccOpts := [nccs]cc_t{}
 	ccOpts[unix.VTIME] = cc_t(vtime / 100)
 	ccOpts[unix.VMIN] = cc_t(vmin)
 

--- a/serial/open_linux.go
+++ b/serial/open_linux.go
@@ -8,14 +8,12 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// NCCS is the number of control character sequences used for c_cc
 const (
 	nccs = 19
 )
 
-//
 // Types from asm-generic/termbits.h
-//
-
 type cc_t byte
 type speed_t uint32
 type tcflag_t uint32
@@ -30,11 +28,9 @@ type termios2 struct {
 	c_ospeed speed_t    // output speed
 }
 
-//
-// Returns a pointer to an instantiates termios2 struct, based on the given
+// makeTermios2 returns a pointer to an instantiates termios2 struct, based on the given
 // OpenOptions. Termios2 is a Linux extension which allows arbitrary baud rates
 // to be specified.
-//
 func makeTermios2(options OpenOptions) (*termios2, error) {
 
 	// Sanity check inter-character timeout and minimum read size options.
@@ -112,6 +108,7 @@ func makeTermios2(options OpenOptions) (*termios2, error) {
 	return t2, nil
 }
 
+// openInternal is the operating system specific port opening, given the OpenOptions
 func openInternal(options OpenOptions) (*Port, error) {
 	// Open the file with RDWR, NOCTTY, NONBLOCK flags
 	// RDWR     : read/write

--- a/serial/open_windows.go
+++ b/serial/open_windows.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// This portion of the package is currently untested and not being worked on
+
 package serial
 
 import (

--- a/serial/port_linux.go
+++ b/serial/port_linux.go
@@ -62,7 +62,6 @@ func (p *Port) DTR() (bool, error) {
 
 // Set the port's DTR pin state
 func (p *Port) SetDTR(state bool) error {
-	// todo(ahollist): Implement
 	var command int
 	if state {
 		command = unix.TIOCMBIS

--- a/serial/port_linux.go
+++ b/serial/port_linux.go
@@ -44,6 +44,35 @@ func (p *Port) SetTimeout(t time.Time) error {
 	return nil
 }
 
+// Get the port's DTR pin state
+func (p *Port) DTR() (bool, error) {
+	var status int
+	_, _, err := unix.Syscall(unix.SYS_IOCTL, p.f.Fd(), unix.TIOCMGET, uintptr(unsafe.Pointer(&status)))
+	if err != 0 {
+		return false, err
+	}
+	if status&unix.TIOCM_DTR > 0 {
+		return true, nil
+	}
+	return false, nil
+}
+
+// Set the port's DTR pin state
+func (p *Port) SetDTR(state bool) error {
+	// todo(ahollist): Implement
+	var command int
+	if state {
+		command = unix.TIOCMBIS
+	} else {
+		command = unix.TIOCMBIC
+	}
+	_, _, err := unix.Syscall(unix.SYS_IOCTL, p.f.Fd(), uintptr(command), 0)
+	if err != 0 {
+		return err
+	}
+	return nil
+}
+
 func NewPort(f *os.File) *Port {
 	return &Port{f}
 }

--- a/serial/port_linux.go
+++ b/serial/port_linux.go
@@ -47,7 +47,8 @@ func (p *Port) SetDeadline(t time.Time) error {
 	return nil
 }
 
-// Get the port's DTR pin state
+// DTR returns the status of the Data Terminal Ready (DTR) line of the port.
+// See: https://en.wikipedia.org/wiki/Data_Terminal_Ready
 func (p *Port) DTR() (bool, error) {
 	var status int
 	err := ioctl(unix.TIOCMGET, p.f.Fd(), uintptr(unsafe.Pointer(&status)))
@@ -60,7 +61,8 @@ func (p *Port) DTR() (bool, error) {
 	return false, nil
 }
 
-// Set the port's DTR pin state
+// SetDTR sets the status of the DTR line of a port to the given state,
+// allowing manual control of the Data Terminal Ready modem line.
 func (p *Port) SetDTR(state bool) error {
 	var command int
 	dtrFlag := unix.TIOCM_DTR

--- a/serial/port_linux.go
+++ b/serial/port_linux.go
@@ -8,26 +8,29 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// Port represents a File opened with serial port options
 type Port struct {
 	f *os.File
 }
 
-// Pass directly through to the file pointer and read the data stream
+// Read reads up to len(b) bytes from the Port's file
+// It will return the number of bytes read and an error, if any
 func (p *Port) Read(b []byte) (int, error) {
 	return p.f.Read(b)
 }
 
-// Pass directly through to the file pointer and write to the stream
+// Write writes len(b) number of bytes to the Port's file.
+// It will return the number of bytes written and an error, if any
 func (p *Port) Write(b []byte) (int, error) {
 	return p.f.Write(b)
 }
 
-// Close the file in our Port
+// Close closes the Port's file, making it unusable for I/O
 func (p *Port) Close() error {
 	return p.f.Close()
 }
 
-// Return the number of bytes waiting in the stream, using ioctl
+// InWaiting returns the number of waiting bytes in the Port's internal buffer.
 func (p *Port) InWaiting() (int, error) {
 	// Funky time
 	var waiting int
@@ -38,6 +41,8 @@ func (p *Port) InWaiting() (int, error) {
 	return waiting, nil
 }
 
+// SetDeadline sets the read and write deadlines for the Port's file.
+// Deadlines are absolute timeouts after which any read or write calls will fail with a timeout error.
 func (p *Port) SetDeadline(t time.Time) error {
 	// Funky Town
 	err := p.f.SetDeadline(t)
@@ -78,6 +83,7 @@ func (p *Port) SetDTR(state bool) error {
 	return nil
 }
 
+// NewPort creates and returns a new Port struct using the given os.File pointer
 func NewPort(f *os.File) *Port {
 	return &Port{f}
 }

--- a/serial/port_linux.go
+++ b/serial/port_linux.go
@@ -13,7 +13,7 @@ type Port struct {
 	f *os.File
 }
 
-// Read reads up to len(b) bytes from the Port's file
+// Read reads up to len(b) bytes from the Port's file.
 // It will return the number of bytes read and an error, if any
 func (p *Port) Read(b []byte) (int, error) {
 	return p.f.Read(b)

--- a/serial/port_linux.go
+++ b/serial/port_linux.go
@@ -63,12 +63,13 @@ func (p *Port) DTR() (bool, error) {
 // Set the port's DTR pin state
 func (p *Port) SetDTR(state bool) error {
 	var command int
+	dtrFlag := unix.TIOCM_DTR
 	if state {
 		command = unix.TIOCMBIS
 	} else {
 		command = unix.TIOCMBIC
 	}
-	err := ioctl(command, p.f.Fd(), 0)
+	err := ioctl(command, p.f.Fd(), uintptr(unsafe.Pointer(&dtrFlag)))
 	if err != nil {
 		return err
 	}

--- a/serial/port_linux.go
+++ b/serial/port_linux.go
@@ -47,8 +47,8 @@ func (p *Port) SetTimeout(t time.Time) error {
 // Get the port's DTR pin state
 func (p *Port) DTR() (bool, error) {
 	var status int
-	_, _, err := unix.Syscall(unix.SYS_IOCTL, p.f.Fd(), unix.TIOCMGET, uintptr(unsafe.Pointer(&status)))
-	if err != 0 {
+	err := ioctl(unix.TIOCMGET, p.f.Fd(), uintptr(unsafe.Pointer(&status)))
+	if err != nil {
 		return false, err
 	}
 	if status&unix.TIOCM_DTR > 0 {
@@ -66,8 +66,8 @@ func (p *Port) SetDTR(state bool) error {
 	} else {
 		command = unix.TIOCMBIC
 	}
-	_, _, err := unix.Syscall(unix.SYS_IOCTL, p.f.Fd(), uintptr(command), 0)
-	if err != 0 {
+	err := ioctl(command, p.f.Fd(), 0)
+	if err != nil {
 		return err
 	}
 	return nil

--- a/serial/port_windows.go
+++ b/serial/port_windows.go
@@ -1,3 +1,5 @@
+// This portion of the package is currently untested and not being worked on
+
 package serial
 
 import (

--- a/serial/serial.go
+++ b/serial/serial.go
@@ -24,7 +24,7 @@ import (
 	"math"
 )
 
-// Valid parity values.
+// ParityMode provides a type for three different parity modes of a serial port
 type ParityMode int
 
 const (


### PR DESCRIPTION
Updating the documentation to standards enforced by "Effective Go", providing comments to exported functions and variables. 

I also un-exported NCCS, we don't need to include that in the external portion of the library. 

waiting on #3, as well. 
