### PR TITLE
feat: Add Device name to Serial Port

### DIFF
--- a/serial/open_linux.go
+++ b/serial/open_linux.go
@@ -140,5 +140,5 @@ func openInternal(options OpenOptions) (*Port, error) {
 		return nil, errno
 	}
 
-	return NewPort(file), nil
+	return NewPort(file, options.PortName), nil
 }

--- a/serial/open_linux.go
+++ b/serial/open_linux.go
@@ -140,5 +140,5 @@ func openInternal(options OpenOptions) (*Port, error) {
 		return nil, errno
 	}
 
-	return NewPort(file, options.PortName), nil
+	return NewPort(file, options), nil
 }

--- a/serial/port_linux.go
+++ b/serial/port_linux.go
@@ -85,6 +85,6 @@ func (p *Port) SetDTR(state bool) error {
 }
 
 // NewPort creates and returns a new Port struct using the given os.File pointer
-func NewPort(f *os.File, name string) *Port {
-	return &Port{f, name}
+func NewPort(f *os.File, options OpenOptions) *Port {
+	return &Port{f, options.PortName}
 }

--- a/serial/port_linux.go
+++ b/serial/port_linux.go
@@ -10,7 +10,8 @@ import (
 
 // Port represents a File opened with serial port options
 type Port struct {
-	f *os.File
+	f          *os.File
+	DeviceName string
 }
 
 // Read reads up to len(b) bytes from the Port's file.
@@ -84,6 +85,6 @@ func (p *Port) SetDTR(state bool) error {
 }
 
 // NewPort creates and returns a new Port struct using the given os.File pointer
-func NewPort(f *os.File) *Port {
-	return &Port{f}
+func NewPort(f *os.File, name string) *Port {
+	return &Port{f, name}
 }


### PR DESCRIPTION
This PR adds the device name as a field in the Port struct

relies on #3 and #5 to be merged before this 