### PR TITLE
fix: SetDeadline and ensure the fd remains nonblocking

### DIFF
--- a/serial/port_linux.go
+++ b/serial/port_linux.go
@@ -11,6 +11,7 @@ import (
 // Port represents a File opened with serial port options
 type Port struct {
 	f          *os.File
+	fd         uintptr
 	DeviceName string
 }
 
@@ -35,7 +36,7 @@ func (p *Port) Close() error {
 func (p *Port) InWaiting() (int, error) {
 	// Funky time
 	var waiting int
-	err := ioctl(unix.TIOCINQ, p.f.Fd(), uintptr(unsafe.Pointer(&waiting)))
+	err := ioctl(unix.TIOCINQ, p.fd, uintptr(unsafe.Pointer(&waiting)))
 	if err != nil {
 		return 0, err
 	}
@@ -57,7 +58,7 @@ func (p *Port) SetDeadline(t time.Time) error {
 // See: https://en.wikipedia.org/wiki/Data_Terminal_Ready
 func (p *Port) DTR() (bool, error) {
 	var status int
-	err := ioctl(unix.TIOCMGET, p.f.Fd(), uintptr(unsafe.Pointer(&status)))
+	err := ioctl(unix.TIOCMGET, p.fd, uintptr(unsafe.Pointer(&status)))
 	if err != nil {
 		return false, err
 	}
@@ -77,7 +78,7 @@ func (p *Port) SetDTR(state bool) error {
 	} else {
 		command = unix.TIOCMBIC
 	}
-	err := ioctl(command, p.f.Fd(), uintptr(unsafe.Pointer(&dtrFlag)))
+	err := ioctl(command, p.fd, uintptr(unsafe.Pointer(&dtrFlag)))
 	if err != nil {
 		return err
 	}
@@ -85,6 +86,6 @@ func (p *Port) SetDTR(state bool) error {
 }
 
 // NewPort creates and returns a new Port struct using the given os.File pointer
-func NewPort(f *os.File, name string) *Port {
-	return &Port{f, name}
+func NewPort(f *os.File, fd uintptr, name string) *Port {
+	return &Port{f, fd, name}
 }


### PR DESCRIPTION
Previously, we were calling `Fd()` on our file object, which sets the underlying file descriptor to be blocking. When we use SetDeadline, if the file is blocking, it does not work on a pending call (and will time out but not return--remaining blocking). 

This saves an unexported pointer to the fd, so we can call things like SetDTR, and querying InWaiting, without worrying that we need to set the fd as nonblocking again. 