### PR TITLE
feat: tcflsh

### DIFF
--- a/serial/port_darwin.go
+++ b/serial/port_darwin.go
@@ -46,6 +46,16 @@ func (p *Port) InWaiting() (int, error) {
 	return waiting, nil
 }
 
+var TCFLSH = 0x540b
+
+func (p *Port) ResetInputBuffer() error {
+	return ioctl(TCFLSH, p.fd, unix.TCIFLUSH)
+}
+
+func (p *Port) ResetOutputBuffer() error {
+	return ioctl(TCFLSH, p.fd, unix.TCOFLUSH)
+}
+
 // SetDeadline sets the read and write deadlines for the Port's file.
 // Deadlines are absolute timeouts after which any read or write calls will fail with a timeout error.
 func (p *Port) SetDeadline(t time.Time) error {

--- a/serial/port_linux.go
+++ b/serial/port_linux.go
@@ -43,6 +43,14 @@ func (p *Port) InWaiting() (int, error) {
 	return waiting, nil
 }
 
+func (p *Port) ResetInputBuffer() error {
+	return ioctl(unix.TCFLSH, p.fd, unix.TCIFLUSH)
+}
+
+func (p *Port) ResetOutputBuffer() error {
+	return ioctl(unix.TCFLSH, p.fd, unix.TCOFLUSH)
+}
+
 // SetDeadline sets the read and write deadlines for the Port's file.
 // Deadlines are absolute timeouts after which any read or write calls will fail with a timeout error.
 func (p *Port) SetDeadline(t time.Time) error {


### PR DESCRIPTION
Add support for resetting of input & output buffers. This is useful in cases where there is a framing error, and we would like to restore to a clean state.
